### PR TITLE
Removed pointless callback (conflicted w/ readme)

### DIFF
--- a/www/printer.js
+++ b/www/printer.js
@@ -1,6 +1,6 @@
 var BrotherPrinter = function () {}
 BrotherPrinter.prototype = {
-    findNetworkPrinters: function (callback, onSuccess, onError) {
+    findNetworkPrinters: function (onSuccess, onError) {
         cordova.exec(onSuccess, onError, 'BrotherPrinter', 'findNetworkPrinters', [])
     },
 


### PR DESCRIPTION
The findNetworkPrinters function (after much head scratching and debugging) appeared to have a pointless empty callback.

When following the docs, the onSuccess callback was coming through the onError callback, which led me to this change.